### PR TITLE
Wait until pdf is generated instead of 30s

### DIFF
--- a/src/service/ScribdDownloader.js
+++ b/src/service/ScribdDownloader.js
@@ -68,6 +68,7 @@ class ScribdDownloader {
             let options = {
                 path: `${output}/${id}.pdf`,
                 printBackground: true,
+                timeout: 0
             }
             let first_page = await page.$("div.outer_page_container div[id^='outer_page_']")
             let style = await first_page.evaluate((el) => el.getAttribute("style"))


### PR DESCRIPTION
I had trouble downloading large files. The progress bar was getting to the end, but then I would have had errors like this:

```
$ node run.js https://www.scribd.com/document/613401279/REDACTED
Mode: DEFAULT
 ████████████████████████████████████████ 100% | ETA: 0s | 410/410
file:///home/tim/local/src/scribd-dl/node_modules/puppeteer-core/lib/esm/puppeteer/common/util.js:251
    const timeoutError = new TimeoutError(`waiting for ${taskName} failed: timeout ${timeout}ms exceeded`);
                         ^

TimeoutError: waiting for Page.printToPDF failed: timeout 30000ms exceeded
    at waitWithTimeout (file:///home/tim/local/src/scribd-dl/node_modules/puppe
teer-core/lib/esm/puppeteer/common/util.js:251:26)
    at CDPPage.createPDFStream (file:///home/tim/local/src/scribd-dl/node_modules/puppeteer-core/lib/esm/puppeteer/common/Page.js:737:30)
    at CDPPage.pdf (file:///home/tim/local/src/scribd-dl/node_modules/puppeteer-core/lib/esm/puppeteer/common/Page.js:746:37)
    at embeds_default (file:///home/tim/local/src/scribd-dl/src/service/ScribdDownloader.js:85:24)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async ScribdDownloader.execute (file:///home/tim/local/src/scribd-dl/src/service/ScribdDownloader.js:34:13)
    at async App.execute (file:///home/tim/local/src/scribd-dl/src/App.js:18:13)
    at async file:///home/tim/local/src/scribd-dl/run.js:16:5

Node.js v18.18.0
```

I updated the code to disable the default 30s timeout on the pdf generation, and it does correctly create the file now.

_Note that page 176+ are blank, which is not expected. But this might be another issue._