### PR TITLE
Update selector to exclude Scribd cookie dialog (DOM changes)

### DIFF
--- a/src/service/ScribdDownloader.js
+++ b/src/service/ScribdDownloader.js
@@ -57,7 +57,7 @@ class ScribdDownloader {
             let title = decodeURIComponent(await div.evaluate((el) => el.href.split('/').pop().trim()))
 
             // remove cookies banners (including legacy 'div.customOptInDialog' for compatibility)
-            const cookieSelectors = ["div.customOptInDialog", "div[role='dialog']"];
+            const cookieSelectors = ["div.customOptInDialog", "div[aria-label='Cookie Consent Banner']"];
             for (const selector of cookieSelectors) {
                 const elements = await page.$$(selector);
                 for (const el of elements) {


### PR DESCRIPTION
Scribd has updated the DOM structure of its cookie consent dialog. With the previous selector, the cookie dialog would be captured in the exported PDF. This update may have been applied only for certain users, so to ensure compatibility, this PR updates the selector to match the new structure while keeping the old selector for backward compatibility.
<img width="1624" height="982" alt="스크린샷 2025-09-02 18 52 46" src="https://github.com/user-attachments/assets/518e4fdc-b517-457f-adad-ccd133858d4a" />
